### PR TITLE
bug fix: show_game window no longer crashes

### DIFF
--- a/src/qlearning/qmodel.py
+++ b/src/qlearning/qmodel.py
@@ -138,6 +138,7 @@ class QModel:
         while not game_over:
             if show:
                 dt = clock.tick(15 * speed)
+                pygame.event.get()
             else:
                 dt = 1000 / (15 * speed)
 


### PR DESCRIPTION
This one line makes games shown while training to no longer crash after a few seconds of playing.